### PR TITLE
adding user-agent

### DIFF
--- a/models/streamline/silver/realtime/streamline__blocks_tx_realtime.sql
+++ b/models/streamline/silver/realtime/streamline__blocks_tx_realtime.sql
@@ -34,7 +34,9 @@ SELECT
         '{Service}/v1/blocks/by_height/' || block_number || '?with_transactions=true',
         OBJECT_CONSTRUCT(
             'Content-Type',
-            'application/json'
+            'application/json',
+            'User-Agent',
+            'Flipside_Crypto/0.1'
         ),
         PARSE_JSON('{}'),
         'Vault/prod/m1/devnet'

--- a/models/streamline/silver/realtime/streamline__transactions_realtime.sql
+++ b/models/streamline/silver/realtime/streamline__transactions_realtime.sql
@@ -81,7 +81,9 @@ numbers AS (
             '{Service}/v1/transactions?start=' || tx_version || '&limit=100',
             OBJECT_CONSTRUCT(
                 'Content-Type',
-                'application/json'
+                'application/json',
+                'User-Agent',
+                'Flipside_Crypto/0.1'
             ),
             PARSE_JSON('{}'),
             'Vault/prod/m1/devnet'

--- a/models/streamline/silver/streamline__chainhead.sql
+++ b/models/streamline/silver/streamline__chainhead.sql
@@ -11,7 +11,9 @@ SELECT
             'Content-Type',
             'application/json',
             'fsc-quantum-state',
-            'livequery'
+            'livequery',
+            'User-Agent',
+            'Flipside_Crypto/0.1'
         ),
         OBJECT_CONSTRUCT(),
         'Vault/prod/m1/devnet'


### PR DESCRIPTION
Movement is rate controlling most user-agents, particularly those with AWS infra like ours. Adding a proper user agent -- clearly doxxed as Flipside -- will return 200 instead of 403 and allow data to catch up from 8/13.